### PR TITLE
Refactor CMakeLists.txt and add behavior tree setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,78 @@
 # BT_Sample PKG
 
 ![1](./fig/1.png)
-## Behavior Tree Setting
 
-### Groot 2 Install
+## Table of Contents
+- [BT\_Sample PKG](#bt_sample-pkg)
+  - [Table of Contents](#table-of-contents)
+  - [Behavior Tree Setup](#behavior-tree-setup)
+    - [Install Groot 2](#install-groot-2)
+    - [Launch Groot 2](#launch-groot-2)
+    - [Install BehaviorTree.CPP (Optional)](#install-behaviortreecpp-optional)
+  - [Build Behavior Tree Sample PKG](#build-behavior-tree-sample-pkg)
+  - [Run Behavior Tree Sample PKG](#run-behavior-tree-sample-pkg)
+    - [Groot2 Launch](#groot2-launch)
+    - [Behavior Tree Sample PKG Launch](#behavior-tree-sample-pkg-launch)
 
-> `.run` 파일을 설치 후 권한을 부여 후 실행
-> 
+## Behavior Tree Setup
 
-[groot install link](https://s3.us-west-1.amazonaws.com/download.behaviortree.dev/groot2_linux_installer/Groot2-v1.5.2-linux-installer.run)
+### Install Groot 2
+
+`.run` 파일을 설치 후 권한을 부여 후 실행
 
 ```bash
-cd ~/Downloads
-sudo chmod 777 Groot2-v1.5.2-linux-installer.run 
+wget https://s3.us-west-1.amazonaws.com/download.behaviortree.dev/groot2_linux_installer/Groot2-v1.5.2-linux-installer.run
+chmod +x Groot2-v1.5.2-linux-installer.run 
 ./Groot2-v1.5.2-linux-installer.run
 ```
 
-### Groot 2 Launch
-
+### Launch Groot 2
 
 ```bash
-cd ~/Groot2/bin ; ./groot2
+cd ~/Groot2/bin
+./groot2
 ```
 
-> 다음 명령어를 통해 groot 로 단축키를 만들어 사용할 수 있습니다.
-> 
+> 다음 명령어를 통해 groot 로 단축키를 만들어 사용할 수 있습니다. 
 
 ```bash
 echo "alias groot='cd ~/Groot2/bin ; ./groot2'" >> ~/.bashrc
 ```
 
-### Behavior Tree Install & Build ( Version 4.5 )
+### Install BehaviorTree.CPP (Optional)
 
-
-> Behavior Tree Install
-> 
+전역적으로 사용할 수 있도록 설치합니다.
 
 ```bash
 cd ~/ros2_ws/src
 git clone https://github.com/BehaviorTree/BehaviorTree.CPP
-```
-
-> Behavior Tree build
-> 
-
-```bash
 sudo apt install libzmq3-dev libboost-dev qtbase5-dev libqt5svg5-dev libzmq3-dev libdw-dev
 cd ~/ros2_ws/src/BehaviorTree.CPP
-mkdir build; cd build
+mkdir build && cd build
 cmake ..
-make -j8
-sudo make install
+sudo make -j8 install
 ```
 
-> 경로 지정
-> 
-
-```bash
-echo "export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> ~/.bashrc
-```
-
-### Install Behavior Tree Sample PKG
+## Build Behavior Tree Sample PKG
 
 ```bash
 cd ~/ros2_ws/src
-git clone https://github.com/AuTURBO/bt_tamplate.git
-cd ~/ros2_ws 
+git clone https://github.com/AuTURBO/bt_template.git
+cd ~/ros2_ws
 colcon build
 ```
 
-## BehaviorTree Sample PKG Launch
+## Run Behavior Tree Sample PKG
 
 ### Groot2 Launch
 
 ```bash
-groot2
+~/Groot2/bin/groot2
 ```
 
 ### Behavior Tree Sample PKG Launch
 
 ```bash
+source ~/ros2_ws/install/local_setup.bash
 ros2 run bt_sample bt_node
 ```

--- a/bt_sample/CMakeLists.txt
+++ b/bt_sample/CMakeLists.txt
@@ -47,7 +47,7 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 install(
-  DIRECTORY config include src launch srv log
+  DIRECTORY config include src srv log
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/bt_sample/CMakeLists.txt
+++ b/bt_sample/CMakeLists.txt
@@ -9,30 +9,28 @@ endif()
 # find dependencies
 ######################################################
 find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED )
-find_package(rclcpp_action REQUIRED )
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(behaviortree_cpp REQUIRED )
 find_package(rosidl_default_generators REQUIRED)
 
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+include(cmake/external/behaviortree_cpp.cmake)
 
 ######################################################
 # add executables
 ######################################################
-
-add_executable(${PROJECT_NAME})
-target_sources(${PROJECT_NAME}
+add_executable(bt_node)
+target_sources(bt_node
     PRIVATE src/bt_node.cpp)
-target_include_directories(${PROJECT_NAME}
+target_include_directories(bt_node
     PRIVATE include)
-ament_target_dependencies(${PROJECT_NAME}
-    rclcpp
-    rclcpp_action
-    std_msgs
-    behaviortree_cpp
-    ament_index_cpp)
+target_link_libraries(bt_node
+    PRIVATE behaviortree_cpp)
+ament_target_dependencies(bt_node
+    PUBLIC  rclcpp
+            rclcpp_action
+            std_msgs
+            ament_index_cpp)
 
 ######################################################
 # test
@@ -47,7 +45,7 @@ endif()
 ######################################################
 # install
 ######################################################
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS bt_node
         DESTINATION lib/${PROJECT_NAME})
 install(DIRECTORY config include src srv log
         DESTINATION share/${PROJECT_NAME})

--- a/bt_sample/CMakeLists.txt
+++ b/bt_sample/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(bt_node)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+    add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 ######################################################
@@ -38,10 +38,10 @@ ament_target_dependencies(${PROJECT_NAME}
 # test
 ######################################################
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
+    find_package(ament_lint_auto REQUIRED)
+    set(ament_cmake_copyright_FOUND TRUE)
+    set(ament_cmake_cpplint_FOUND TRUE)
+    ament_lint_auto_find_test_dependencies()
 endif()
 
 ######################################################

--- a/bt_sample/CMakeLists.txt
+++ b/bt_sample/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(bt_node)
+project(bt_sample)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic)

--- a/bt_sample/CMakeLists.txt
+++ b/bt_sample/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(bt_sample)
+project(bt_node)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -11,55 +11,45 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED )
 find_package(rclcpp_action REQUIRED )
-find_package(behaviortree_cpp REQUIRED )
 find_package(std_msgs REQUIRED)
+find_package(behaviortree_cpp REQUIRED )
 find_package(rosidl_default_generators REQUIRED)
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 ######################################################
+# add executables
+######################################################
 
-set(dependencies
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME}
+    PRIVATE src/bt_node.cpp)
+target_include_directories(${PROJECT_NAME}
+    PRIVATE include)
+ament_target_dependencies(${PROJECT_NAME}
     rclcpp
     rclcpp_action
-    ament_index_cpp
-    behaviortree_cpp
     std_msgs
-    )
-
-include_directories(
-  ${PROJECT_SOURCE_DIR}/include
-)
-
-
-add_executable(bt_node src/bt_node.cpp)
-ament_target_dependencies(bt_node
-  std_msgs
-  ${dependencies}
-)
+    behaviortree_cpp
+    ament_index_cpp)
 
 ######################################################
-
-
-install(TARGETS
-  bt_node
-  DESTINATION lib/${PROJECT_NAME}
-)
-install(
-  DIRECTORY config include src srv log
-  DESTINATION share/${PROJECT_NAME}
-)
-
+# test
 ######################################################
-
-
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   set(ament_cmake_copyright_FOUND TRUE)
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
+
+######################################################
+# install
+######################################################
+install(TARGETS ${PROJECT_NAME}
+        DESTINATION lib/${PROJECT_NAME})
+install(DIRECTORY config include src srv log
+        DESTINATION share/${PROJECT_NAME})
 
 ament_package()

--- a/bt_sample/cmake/external/behaviortree_cpp.cmake
+++ b/bt_sample/cmake/external/behaviortree_cpp.cmake
@@ -1,0 +1,19 @@
+find_package(behaviortree_cpp CONFIG)
+
+if(NOT behaviortree_cpp_FOUND)
+    message(STATUS "Downloading BehaviorTree.CPP")
+    include(FetchContent)
+
+    set(BTCPP_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
+    set(BTCPP_BUILD_TOOLS OFF CACHE BOOL "Build commandline tools" FORCE)
+    set(BTCPP_EXAMPLES    OFF CACHE BOOL "Build tutorials and examples" FORCE)
+    set(BTCPP_UNIT_TESTS  OFF CACHE BOOL "Build the unit tests" FORCE)
+
+    set(FETCHCONTENT_QUIET OFF)
+    FetchContent_Declare(behavior_tree_cpp
+        GIT_REPOSITORY https://github.com/BehaviorTree/BehaviorTree.CPP.git
+        GIT_TAG        4.5.2
+        GIT_PROGRESS   TRUE
+        GIT_SHALLOW    TRUE)
+    FetchContent_MakeAvailable(behavior_tree_cpp)
+endif()

--- a/bt_sample/package.xml
+++ b/bt_sample/package.xml
@@ -8,15 +8,9 @@
   <license>TODO: License declaration</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>geometry_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>tf2</depend>
-  <depend>tf2_geometry_msgs</depend>
-
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
-  <depend>behaviortree_cpp</depend>
-  <depend>bt_interfaces</depend>
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This pull request refactors the CMakeLists.txt file for bt_node, updates the project name, and adds behavior tree setup instructions to the README file.

- CMake FetchContent를 사용해서 굳이 BehaviorTree.CPP 라이브러리를 별도로 전역 Path에 설치하지 않아도 의존성 문제가 생기지 않도록 수정했습니다.
- CMakeLists.txt랑 README.md도 맞춰서 일부 리팩토링 진행했습니다.